### PR TITLE
Fix bad syntax in generated LaTeX

### DIFF
--- a/colorproc.rb
+++ b/colorproc.rb
@@ -93,7 +93,7 @@ colors.lines.each do |line|
 
 
     #latexcolor = "\\definecolor{#{colorname}}%<br />{rgb}{#{colorvalue}}"
-    latexcolor = "\\definecolor{#{colorname}}{rgb}{#{colorvalue}}"
+    latexcolor = "\\definecolor{#{colorname.tr('#','')}}{rgb}{#{colorvalue}}"
     print "<td class=\"latex-definition\">", latexcolor, "</td>","\n"
 
 


### PR DESCRIPTION
`#` has special meaning in TeX -- using it in a color name is an error.
